### PR TITLE
Adapt to new array syntax

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub fn oneshot(input: &[u8], seed: u64) -> u64 { #![inline]
 
 #[deriving(Copy)]
 pub struct XXState {
-    memory: [u64, ..4],
+    memory: [u64; 4],
     v1: u64,
     v2: u64,
     v3: u64,

--- a/src/xxh32.rs
+++ b/src/xxh32.rs
@@ -26,7 +26,7 @@ pub fn oneshot(input: &[u8], seed: u32) -> u32 {
 #[deriving(Copy)]
 pub struct XXState {
     // field names match the C implementation
-    memory: [u32, ..4],
+    memory: [u32; 4],
     total_len: u64,
     v1: u32,
     v2: u32,


### PR DESCRIPTION
`[ty, ..n]` does not work anymore but was replaced by `[ty; n]` sytanx.