### PR TITLE
Get rid of warnings because of deprecated `#[deriving(x)]` constructs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ pub fn oneshot(input: &[u8], seed: u64) -> u64 { #![inline]
     state.digest()
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct XXState {
     memory: [u64, ..4],
     v1: u64,
@@ -253,7 +253,7 @@ impl Clone for XXState {
 }
 
 /// `XXHasher` computes the xxHash64 algorithm from a stream of bytes.
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct XXHasher {
     seed: u64
 }

--- a/src/xxh32.rs
+++ b/src/xxh32.rs
@@ -23,7 +23,7 @@ pub fn oneshot(input: &[u8], seed: u32) -> u32 {
     state.digest()
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct XXState {
     // field names match the C implementation
     memory: [u32, ..4],
@@ -163,7 +163,7 @@ impl XXState {
     }}
 }
 
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct XXHasher {
     seed: u32
 }


### PR DESCRIPTION
Using new `#[derive(x)]` syntax.